### PR TITLE
start controller-runtime client cache

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -224,6 +224,7 @@ func (a *actuator) InjectClient(client client.Client) error {
 	if err != nil {
 		return err
 	}
+	clientInterface.Start(context.Background())
 	a.clientGardenlet = clientInterface.Client()
 	return nil
 }


### PR DESCRIPTION
I guess it was done automatically before. Without this, the reconiliation fails with (coming from the first call to clientGardenlet.Get())

`{"level":"error","ts":"2022-08-05T14:14:08.810Z","logger":"shoot_flux_lifecycle_controller","msg":"Error","namespace":"shoot--23ke-ci--23ke-run-4259","name":"shoot-flux","error":"Error reco
nciling extension: the cache is not started, can not read objects","stacktrace":"github.com/gardener/gardener/extensions/pkg/controller.(*statusUpdater).Error\n\t/go/src/github.com/23techno
logies/gardener-extension-shoot-flux/vendor/github.com/gardener/gardener/extensions/pkg/controller/status.go:132\ngithub.com/gardener/gardener/extensions/pkg/controller/extension.(*reconcil
er).reconcile\n\t/go/src/github.com/23technologies/gardener-extension-shoot-flux/vendor/github.com/gardener/gardener/extensions/pkg/controller/extension/reconciler.go:156\ngithub.com/garden
er/gardener/extensions/pkg/controller/extension.(*reconciler).Reconcile\n\t/go/src/github.com/23technologies/gardener-extension-shoot-flux/vendor/github.com/gardener/gardener/extensions/pkg
/controller/extension/reconciler.go:138\ngithub.com/gardener/gardener/pkg/controllerutils/reconciler.(*operationAnnotationWrapper).Reconcile\n\t/go/src/github.com/23technologies/gardener-ex
tension-shoot-flux/vendor/github.com/gardener/gardener/pkg/controllerutils/reconciler/operation_annotation_wrapper.go:73\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller
).Reconcile\n\t/go/src/github.com/23technologies/gardener-extension-shoot-flux/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:121\nsigs.k8s.io/controller-runtim
e/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/src/github.com/23technologies/gardener-extension-shoot-flux/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/con
troller.go:320\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/src/github.com/23technologies/gardener-extension-shoot-flux/vendor/sigs.k8s.i
o/controller-runtime/pkg/internal/controller/controller.go:273\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/src/github.com/23technologies/garde
ner-extension-shoot-flux/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234"}`