### PR TITLE
Download flux-install.yaml only once

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -80,21 +80,20 @@ func (a *actuator) Reconcile(ctx context.Context, ex *extensionsv1alpha1.Extensi
 		return err
 	}
 
-	fluxVersion, err := getFluxVersion(fluxConfigMap.Data)
-	if err != nil {
-		a.logger.Error(err, "I was not able to determine a flux release with respect to the version you defined. Check the configmap in the garden cluster for the version.")
-		return err
-	}
 
 	// --------------------- Flux Installation ----------------------------
-
 	if !existsManagedResource(ctx, a.client, extensionNamespace, constants.ManagedResourceNameFluxInstall) {
+
+		fluxVersion, err := getFluxVersion(fluxConfigMap.Data)
+		if err != nil {
+			a.logger.Error(err, "I was not able to determine a flux release with respect to the version you defined. Check the configmap in the garden cluster for the version.")
+			return err
+		}
 		// Create the resource for the flux installation
 		shootResourceFluxInstall, err := createShootResourceFluxInstall(fluxVersion)
 		if err != nil {
 			return err
 		}
-
 		// deploy the managed resource for the flux installatation
 		err = managedresources.CreateForShoot(ctx, a.client, extensionNamespace, constants.ManagedResourceNameFluxInstall, true, shootResourceFluxInstall)
 		if err != nil {


### PR DESCRIPTION
This should provide a hotfix for hitting the Github-API ratelimits

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>

-------

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness 
/kind enhancement 

**What this PR does / why we need it**:
It prevents from hitting GitHub ratelimits just because of a request for the current latest version of fluxcd.

**Which issue(s) this PR fixes**:
Fixes #6

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user 
Hitting GitHub ratelimits due to multiple requests for the latest version of fluxcd are avoided
```